### PR TITLE
Link to PayPal Donate page in different languages

### DIFF
--- a/config/_default/languages.toml
+++ b/config/_default/languages.toml
@@ -13,6 +13,8 @@ description = """
 """
 # PayPal image url from https://www.paypal.com/donate/buttons/unhosted
 paypalDonateImage = "https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"
+# A country where PayPal has support for the language must be chosen. Click a Donate button and modify the GET parameters "country.x" and "locale.x" to find what is supported.
+paypalCountry = "US"
 
 [de]
 title = "Let's Encrypt - Freie SSL/TLS Zertifikate"
@@ -26,6 +28,7 @@ description = """
   herausgebracht für Sie durch <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 paypalDonateImage = "https://www.paypalobjects.com/de_DE/DE/i/btn/btn_donateCC_LG.gif"
+paypalCountry = "DE"
 
 [es]
 title = "Let's Encrypt - Certificados SSL/TLS Gratuitos"
@@ -38,6 +41,7 @@ description = """
   Let's Encrypt es una autoridad de certificación gratuita, automatizada, y abierta traida a ustedes por la organización sin ánimos de lucro <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 paypalDonateImage = "https://www.paypalobjects.com/es_XC/i/btn/btn_donateCC_LG.gif"
+paypalCountry = "ES"
 
 [fr]
 title = "Let's Encrypt - Certificats SSL/TLS gratuits"
@@ -51,6 +55,7 @@ description = """
   apporté par l'<a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>, organisme à but non lucratif.
 """
 paypalDonateImage = "https://www.paypalobjects.com/fr_FR/FR/i/btn/btn_donateCC_LG.gif"
+paypalCountry = "FR"
 
 [id]
 title = "Let's Encrypt - Sertifikat SSL/TLS Gratis"
@@ -64,6 +69,7 @@ description = """
   dipersembahkan oleh organisasi non-profit <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 paypalDonateImage = "https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"
+paypalCountry = "ID"
 
 [ja]
 title = "Let's Encrypt - フリーな SSL/TLS 証明書"
@@ -77,6 +83,7 @@ description = """
   authority brought to you by the non-profit <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 paypalDonateImage = "https://www.paypalobjects.com/ja_JP/JP/i/btn/btn_donateCC_LG.gif"
+paypalCountry = "JP"
 
 [ko]
 title = "Let's Encrypt - 무료 SSL/TLS 인증서"
@@ -89,6 +96,7 @@ description = """
   Let's Encrypt는 <a href="https://www.abetterinternet.org/"> 비영리 인터넷 보안 연구 그룹 (ISRG)</a>에서 가져온 무료, 자동 및 공개 인증 기관입니다.
 """
 paypalDonateImage = "https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"
+paypalCountry = "KR"
 
 [pt-br]
 title = "Let's Encrypt - Certificados SSL/TLS Gratuitos"
@@ -102,6 +110,7 @@ description = """
   que se tornou possível graças à organização sem fins lucrativos <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>
 """
 paypalDonateImage = "https://www.paypalobjects.com/pt_BR/BR/i/btn/btn_donateCC_LG.gif"
+paypalCountry = "BR"
 
 [ru]
 title = "Let's Encrypt - Free SSL/TLS Certificates"
@@ -115,6 +124,7 @@ description = """
   некоммерческой организацией <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 paypalDonateImage = "https://www.paypalobjects.com/ru_RU/RU/i/btn/btn_donateCC_LG.gif"
+paypalCountry = "RU"
 
 [sr-sp]
 title = "Let's Encrypt - Besplatni SSL/TLS Sertifikati"
@@ -128,6 +138,7 @@ description = """
   telo omogućeno od strane ne profitne <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a> grupe.
 """
 paypalDonateImage = "https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"
+paypalCountry = "SP"
 
 [sv]
 title = "Let's Encrypt - Gratis SSL/TLS-certifikat"
@@ -143,6 +154,7 @@ description = """
   skapad av icke-vinstdrivande <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 paypalDonateImage = "https://www.paypalobjects.com/sv_SE/SE/i/btn/btn_donateCC_LG.gif"
+paypalCountry = "SE"
 
 [zh-cn]
 title = "Let's Encrypt - 免费的SSL/TLS证书"
@@ -156,6 +168,7 @@ description = """
   style="white-space:nowrap;">互联网安全研究小组（ISRG）</a>运营。
 """
 paypalDonateImage = "https://www.paypalobjects.com/zh_XC/i/btn/btn_donateCC_LG.gif"
+paypalCountry = "CN"
 
 [zh-tw]
 title = "Let's Encrypt - 免費SSL/TLS憑證"
@@ -168,3 +181,4 @@ description = """
   Let's Encrypt 是由非營利性網際網路安全研究小組（ISRG）提供給您的免費、自動化和開放的憑證頒發機構。
   """
 paypalDonateImage = "https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"
+paypalCountry = "TW"

--- a/layouts/shortcodes/paypal.html
+++ b/layouts/shortcodes/paypal.html
@@ -1,4 +1,6 @@
 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
+  <input type="hidden" name="country" value="{{ .Page.Language.Params.paypalCountry }}" />
+  <input type="hidden" name="lc" value="{{ .Page.Language }}" />
   <input type="hidden" name="cmd" value="_s-xclick" />
   <input type="hidden" name="hosted_button_id" value="AF6VLVH49A3QN" />
   <input type="image" src="{{ .Page.Language.Params.paypalDonateImage }}" border="0" name="submit" title="{{ i18n "paypal_donate_title" }}" alt="{{ i18n "paypal_donate_alt" }}" />

--- a/layouts/shortcodes/paypal.html
+++ b/layouts/shortcodes/paypal.html
@@ -1,6 +1,6 @@
 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
   <input type="hidden" name="country" value="{{ .Page.Language.Params.paypalCountry }}" />
-  <input type="hidden" name="lc" value="{{ .Page.Language }}" />
+  <input type="hidden" name="lc" value="{{ .Page.Language.Params.languageCode }}" />
   <input type="hidden" name="cmd" value="_s-xclick" />
   <input type="hidden" name="hosted_button_id" value="AF6VLVH49A3QN" />
   <input type="image" src="{{ .Page.Language.Params.paypalDonateImage }}" border="0" name="submit" title="{{ i18n "paypal_donate_title" }}" alt="{{ i18n "paypal_donate_alt" }}" />


### PR DESCRIPTION
In order to show the PayPal Donate page in a particular language one has
to set two POST parameters:

* "lc" to either the full locale like en_US or just US (case
  insensitive)
* "country" to a country where that language is spoken or more
  specifically where PayPal supports that language (case insensitive)

Use the existing language codes for the "lc" parameter but introduce a
new variable paypalCountry for use in the "country" parameter and choose
one country per language.

Elaboration and discussions around this have taken place in issue #783.