### PR TITLE
PayPal: Remove unnecessary paypalCountry

### DIFF
--- a/config/_default/languages.toml
+++ b/config/_default/languages.toml
@@ -14,7 +14,6 @@ description = """
 # PayPal image url from https://www.paypal.com/donate/buttons/unhosted
 paypalDonateImage = "https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"
 # A country where PayPal has support for the language must be chosen. Click a Donate button and modify the GET parameters "country.x" and "locale.x" to find what is supported.
-paypalCountry = "US"
 
 [de]
 title = "Let's Encrypt - Freie SSL/TLS Zertifikate"
@@ -28,7 +27,6 @@ description = """
   herausgebracht für Sie durch <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 paypalDonateImage = "https://www.paypalobjects.com/de_DE/DE/i/btn/btn_donateCC_LG.gif"
-paypalCountry = "DE"
 
 [es]
 title = "Let's Encrypt - Certificados SSL/TLS Gratuitos"
@@ -41,7 +39,6 @@ description = """
   Let's Encrypt es una autoridad de certificación gratuita, automatizada, y abierta traida a ustedes por la organización sin ánimos de lucro <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 paypalDonateImage = "https://www.paypalobjects.com/es_XC/i/btn/btn_donateCC_LG.gif"
-paypalCountry = "ES"
 
 [fr]
 title = "Let's Encrypt - Certificats SSL/TLS gratuits"
@@ -55,7 +52,6 @@ description = """
   apporté par l'<a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>, organisme à but non lucratif.
 """
 paypalDonateImage = "https://www.paypalobjects.com/fr_FR/FR/i/btn/btn_donateCC_LG.gif"
-paypalCountry = "FR"
 
 [id]
 title = "Let's Encrypt - Sertifikat SSL/TLS Gratis"
@@ -69,13 +65,12 @@ description = """
   dipersembahkan oleh organisasi non-profit <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 paypalDonateImage = "https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"
-paypalCountry = "ID"
 
 [ja]
 title = "Let's Encrypt - フリーな SSL/TLS 証明書"
 contentDir = "content/ja"
 languageName ="日本語"
-languageCode= "ja"
+languageCode= "ja-jp"
 beforeColon= ""
 weight = 60
 description = """
@@ -83,7 +78,6 @@ description = """
   authority brought to you by the non-profit <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 paypalDonateImage = "https://www.paypalobjects.com/ja_JP/JP/i/btn/btn_donateCC_LG.gif"
-paypalCountry = "JP"
 
 [ko]
 title = "Let's Encrypt - 무료 SSL/TLS 인증서"
@@ -96,7 +90,6 @@ description = """
   Let's Encrypt는 <a href="https://www.abetterinternet.org/"> 비영리 인터넷 보안 연구 그룹 (ISRG)</a>에서 가져온 무료, 자동 및 공개 인증 기관입니다.
 """
 paypalDonateImage = "https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"
-paypalCountry = "KR"
 
 [pt-br]
 title = "Let's Encrypt - Certificados SSL/TLS Gratuitos"
@@ -110,7 +103,6 @@ description = """
   que se tornou possível graças à organização sem fins lucrativos <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>
 """
 paypalDonateImage = "https://www.paypalobjects.com/pt_BR/BR/i/btn/btn_donateCC_LG.gif"
-paypalCountry = "BR"
 
 [ru]
 title = "Let's Encrypt - Free SSL/TLS Certificates"
@@ -124,7 +116,6 @@ description = """
   некоммерческой организацией <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 paypalDonateImage = "https://www.paypalobjects.com/ru_RU/RU/i/btn/btn_donateCC_LG.gif"
-paypalCountry = "RU"
 
 [sr-sp]
 title = "Let's Encrypt - Besplatni SSL/TLS Sertifikati"
@@ -138,13 +129,12 @@ description = """
   telo omogućeno od strane ne profitne <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a> grupe.
 """
 paypalDonateImage = "https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"
-paypalCountry = "SP"
 
 [sv]
 title = "Let's Encrypt - Gratis SSL/TLS-certifikat"
 contentDir = "content/sv"
 languageName ="Svenska"
-languageCode= "sv"
+languageCode= "sv-se"
 #if colon ":" must be prefixed with a space : "&nbsp;" (example in [fr])
 beforeColon= ""
 # Weight used for sorting. (alphabetical order using languageCode, with English first)
@@ -154,7 +144,6 @@ description = """
   skapad av icke-vinstdrivande <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 paypalDonateImage = "https://www.paypalobjects.com/sv_SE/SE/i/btn/btn_donateCC_LG.gif"
-paypalCountry = "SE"
 
 [zh-cn]
 title = "Let's Encrypt - 免费的SSL/TLS证书"
@@ -168,7 +157,6 @@ description = """
   style="white-space:nowrap;">互联网安全研究小组（ISRG）</a>运营。
 """
 paypalDonateImage = "https://www.paypalobjects.com/zh_XC/i/btn/btn_donateCC_LG.gif"
-paypalCountry = "CN"
 
 [zh-tw]
 title = "Let's Encrypt - 免費SSL/TLS憑證"
@@ -181,4 +169,3 @@ description = """
   Let's Encrypt 是由非營利性網際網路安全研究小組（ISRG）提供給您的免費、自動化和開放的憑證頒發機構。
   """
 paypalDonateImage = "https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"
-paypalCountry = "TW"

--- a/layouts/shortcodes/paypal.html
+++ b/layouts/shortcodes/paypal.html
@@ -1,5 +1,5 @@
 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-  <input type="hidden" name="country" value="{{ .Page.Language.Params.paypalCountry }}" />
+  <input type="hidden" name="country" value="{{ index (last 1 (split .Page.Language.Params.languageCode "-")) 0 }}" />
   <input type="hidden" name="lc" value="{{ .Page.Language.Params.languageCode }}" />
   <input type="hidden" name="cmd" value="_s-xclick" />
   <input type="hidden" name="hosted_button_id" value="AF6VLVH49A3QN" />


### PR DESCRIPTION
The new variable paypalCountry is not needed. Let's use the part after
the dash in the languageCode instead. Add a country to the few
languageCodes not having it and where it's not the same as the language
part.

Even if a languageCode is set to only "de" it will still work given it's
the code for both the country and the language.