### PR TITLE
[TEST] html5validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ before_install:
   - wget https://github.com/gohugoio/hugo/releases/download/v0.64.1/hugo_extended_0.64.1_Linux-64bit.deb
   - echo "19f60f8bbfbe060635e127b8d0c32b9c7a0dd3fbc6830add4a86d0d3c55ca3d1 hugo_extended_0.64.1_Linux-64bit.deb" | sha256sum -c - || exit 1;
   - sudo dpkg -i hugo_extended_0.64.1_Linux-64bit.deb
+  - pip install --user html5validator
 
 install:
-  - npm install && npm run build && npm test
+  - npm install
+  - npm run build
+  - npm test
+  - html5validator --root public --blacklist documents --also-check-css --format text

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
   - npm install
   - npm run build
   - npm test
-  - html5validator --root public --blacklist documents --also-check-css --format text
+  - html5validator --root public --blacklist documents donate ct-logs --also-check-css --format text


### PR DESCRIPTION
https://validator.w3.org/nu/about.html
https://github.com/svenkreiss/html5validator
Fix: 
- https://github.com/letsencrypt/website/pull/928
- https://github.com/letsencrypt/website/pull/927
- https://github.com/letsencrypt/website/pull/926
- https://github.com/letsencrypt/website/pull/925
- https://github.com/letsencrypt/website/pull/924
- https://github.com/letsencrypt/website/pull/940
- https://github.com/letsencrypt/website/pull/944
TODO;
- #31/#32
- Last invalid items

NB: htmlhint is still useful, for example to detect "ad" classes and to force a coding style.